### PR TITLE
Only show tweets containing "{word} the {word}"

### DIFF
--- a/app/controllers/names_controller.rb
+++ b/app/controllers/names_controller.rb
@@ -1,6 +1,6 @@
 class NamesController < ApplicationController
   def index
     client = TwitterClient.new
-    @search_results = client.search
+    @search_results = NameFilter.new(client.search).filter
   end
 end

--- a/app/models/name_filter.rb
+++ b/app/models/name_filter.rb
@@ -1,0 +1,13 @@
+class NameFilter
+  MATCHING_FILTER = /[a-z].+ the [a-z].+/i
+
+  def initialize(tweet_texts)
+    @tweet_texts = tweet_texts
+  end
+
+  def filter
+    @tweet_texts.select do |text|
+      text =~ MATCHING_FILTER
+    end
+  end
+end

--- a/spec/features/user_views_results_spec.rb
+++ b/spec/features/user_views_results_spec.rb
@@ -8,5 +8,13 @@ feature "User visits homepage" do
 
     expect(page).to have_content "Tyler the Creator"
   end
+
+  scenario "and does not see tweets without X the Y" do
+    stub_matching_search(" the ", "hi there")
+
+    visit root_path
+
+    expect(page).not_to have_content "hi there"
+  end
 end
 

--- a/spec/models/name_filter_spec.rb
+++ b/spec/models/name_filter_spec.rb
@@ -1,0 +1,23 @@
+require "spec_helper"
+
+describe NameFilter do
+  context "#filter" do
+    it "filters out tweets that do not match 'X the Y'" do
+      tweet_texts = [
+        "This is lowercase tyler the creator",
+        "This is uppercase Tyler the Creator",
+        "This is all one word: OnetheWord",
+        "BLORG THE HEARTLESS",
+      ]
+
+      name_filter = NameFilter.new(tweet_texts)
+      results = name_filter.filter
+
+      expect(results).to eq [
+        "This is lowercase tyler the creator",
+        "This is uppercase Tyler the Creator",
+        "BLORG THE HEARTLESS",
+      ]
+    end
+  end
+end


### PR DESCRIPTION
We want to filter it down to _just_ "{word} the {word}" eventually, but only
showing tweets that contain the phrase is a good start.
